### PR TITLE
HB-5082: fix for PetCards displaying 'act quickly' banner for bonded …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aap/periodic",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aap/periodic",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "A design system for AAP's Vue components",
   "main": "dist/system/system.js",
   "files": [

--- a/src/patterns/PetCard/PetCard.html
+++ b/src/patterns/PetCard/PetCard.html
@@ -19,11 +19,9 @@
     <Heading level="h4"
       font-weight="bold">{{ pet.name }}</Heading>
     <Paragraph font-size="s">
-      {{ petFormatted.sex }}, {{ petFormatted.age }}
-      <span v-if="pet.specialNeeds">,
+      {{ petFormatted.sex }}, {{ petFormatted.age }}<span v-if="pet.specialNeeds">,
         <span class="orange">Special Needs</span>
-      </span>
-      <span v-if="pet.bondedTo">,
+      </span><span v-if="pet.bondedTo">,
         <span class="orange">Bonded Pair</span>
       </span>
       <span v-if="breeds">

--- a/src/patterns/PetCard/PetCard.html
+++ b/src/patterns/PetCard/PetCard.html
@@ -12,14 +12,20 @@
     </span>
     <div v-if="pet.status == 'adopted'"
       class="border-bottom blue">Adopted</div>
-    <div v-else-if="pet.specialNeeds || pet.bondedTo || pet.actQuickly"
+    <div v-else-if="pet.actQuickly"
       class="border-bottom orange">Act Quickly</div>
   </a>
   <div class="content">
     <Heading level="h4"
       font-weight="bold">{{ pet.name }}</Heading>
     <Paragraph font-size="s">
-      {{ petFormatted.sex }}, {{ petFormatted.age }}<span v-if="pet.specialNeeds">, <span class="orange">Special Needs</span></span><span v-if="pet.specialNeeds">, <span class="orange">Bonded Pair</span></span>
+      {{ petFormatted.sex }}, {{ petFormatted.age }}
+      <span v-if="pet.specialNeeds">,
+        <span class="orange">Special Needs</span>
+      </span>
+      <span v-if="pet.bondedTo">,
+        <span class="orange">Bonded Pair</span>
+      </span>
       <span v-if="breeds">
         <br>
         {{ pet.breedName }}

--- a/src/patterns/PetCard/PetCard.vue
+++ b/src/patterns/PetCard/PetCard.vue
@@ -134,7 +134,7 @@ export default {
               "status": "available",
               "city": "Spanish Fork",
               "state": "UT",
-              "actQuickly": false,
+              "actQuickly": true,
               "breedName": "Bloodhound",
               "secondaryBreedName": "Great Pyrenees"
             },


### PR DESCRIPTION
…pairs and special needs. This fix also corrects the presentation of the "bonded pair" and "special needs" labels.