### PR TITLE
GD-6: Resolve accessibility issues on Pet Search Results page

### DIFF
--- a/src/elements/VSpacer.vue
+++ b/src/elements/VSpacer.vue
@@ -1,7 +1,7 @@
 |<template>
   <component
     :is="tag"
-    :style="{ lineHeight: height, height: height, width: '100%' }"> <slot /> </component>
+    :style="{ height: height, width: '100%' }"> <slot /> </component>
 </template>
 
 <script>


### PR DESCRIPTION
Partly resolves "1.17 Do not use absolute fixed text" issue. I haven't found a single use of VSpacer with a text content among all repositories so it's save to remove.